### PR TITLE
Add krakendJson to values to override file

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -4,4 +4,8 @@ metadata:
   name: {{ template "krakend.fullname" . }}-configmap
 data:
   krakend.json: |-
+{{- if eq .Values.krakendJson "" }}
 {{ .Files.Get "krakend.json" | indent 4 }}
+{{- else }}
+{{ .Values.krakendJson | indent 4 }}
+{{- end}}

--- a/values.yaml
+++ b/values.yaml
@@ -77,3 +77,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+krakendJson: ""


### PR DESCRIPTION
This will allow the user to override the `krakend.json` file included with the helm chart with a configuration of their own.