### PR TITLE
Add ability to configure probes

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -44,14 +44,18 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml .Values.probes.liveness.probe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
           readinessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml .Values.probes.readiness.probe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            {{- toYaml .Values.probes.startup.probe | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/values.yaml
+++ b/values.yaml
@@ -79,3 +79,23 @@ tolerations: []
 affinity: {}
 
 krakendJson: ""
+
+probes:
+  liveness:
+    enabled: true
+    probe:
+      httpGet:
+        path: /
+        port: http
+  readiness:
+    enabled: true
+    probe:
+      httpGet:
+        path: /
+        port: http
+  startup:
+    enabled: false
+    probe:
+      httpGet:
+        path: /
+        port: http


### PR DESCRIPTION
With the ability to provide a custom krakend.json file in https://github.com/mikescandy/krakend-helm/pull/2, we should enable the user the ability to configure probes.