### PR TITLE
Allow additional volumes, volumeMounts, and env

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -8,4 +8,4 @@ data:
 {{ .Files.Get "krakend.json" | indent 4 }}
 {{- else }}
 {{ .Values.krakendJson | indent 4 }}
-{{- end}}
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
         - name: config
           configMap:
             name: {{ template "krakend.fullname" . }}-configmap
+        {{- if .Values.addlVolumes }}
+        {{- toYaml .Values.addlVolumes | nindent 8 }}
+        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -40,6 +43,13 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/krakend/
+            {{- if .Values.addlVolumeMounts }}
+            {{- toYaml .Values.addlVolumeMounts | nindent 12 }}
+            {{- end }}
+          env:
+            {{- if .Values.env }}
+            {{- toYaml .Values.env | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/values.yaml
+++ b/values.yaml
@@ -79,3 +79,6 @@ tolerations: []
 affinity: {}
 
 krakendJson: ""
+addlVolumes: []
+addlVolumeMounts: []
+env: []


### PR DESCRIPTION
Provide the user the ability to provide additional volumes, volumeMounts, and env variables. This is in enablement of the [flexible configuration](https://www.krakend.io/docs/configuration/flexible-config/) feature provided by Krakend.