### PR TITLE
Change the healthcheck endpoint for liveness/readiness probes

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -54,14 +54,18 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /
-              port: http
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.livenessProbe.port }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /
-              port: http
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.readinessProbe.port }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/values.yaml
+++ b/values.yaml
@@ -72,6 +72,16 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+livenessProbe:
+  enabled: true
+  path: /__health
+  port: http
+
+readinessProbe:
+  enabled: true
+  path: /__health
+  port: http
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
Change the healthcheck endpoint for liveness/readiness probes, and take out the configurations in the values file.

The change is reflecting some issues I had while deploying this chart, and is referring the documentation at the [docker hub page](https://hub.docker.com/r/devopsfaith/krakend/) of the image used by default.

I'm not sure if we should configure the other settings of the probes explicitly as well.